### PR TITLE
[RFC] store: add compression support

### DIFF
--- a/cmd/oklog/store.go
+++ b/cmd/oklog/store.go
@@ -56,6 +56,7 @@ func runStore(args []string) error {
 		segmentPurge             = flagset.Duration("store.segment-purge", defaultStoreSegmentPurge, "purge deleted segment files after this long")
 		uiLocal                  = flagset.Bool("ui.local", false, "ignore embedded files and go straight to the filesystem")
 		filesystem               = flagset.String("filesystem", defaultFilesystem, "real, virtual, nop")
+		compression              = flagset.String("compression", "", "gzip, lz4, zst")
 		clusterPeers             = stringslice{}
 	)
 	flagset.Var(&clusterPeers, "peer", "cluster peer host:port (repeatable)")
@@ -203,10 +204,16 @@ func runStore(args []string) error {
 	default:
 		return errors.Errorf("invalid -filesystem %q", *filesystem)
 	}
+
+	if !store.IsCompressionValid(*compression) {
+		return errors.Errorf("invalid -compression %q", *compression)
+	}
+
 	storeLog, err := store.NewFileLog(
 		fsys,
 		*storePath,
 		*segmentTargetSize, *segmentBufferSize,
+		*compression,
 		store.LogReporter{Logger: log.With(logger, "component", "FileLog")},
 	)
 	if err != nil {

--- a/pkg/store/api_test.go
+++ b/pkg/store/api_test.go
@@ -109,7 +109,7 @@ func newFixtureAPI(t *testing.T) (*API, error) {
 
 	// Construct a virtual file log.
 	filesys := fs.NewVirtualFilesystem()
-	filelog, err := NewFileLog(filesys, "/", 10240, 1024, logReporter)
+	filelog, err := NewFileLog(filesys, "/", 10240, 1024, "", logReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/store/compression.go
+++ b/pkg/store/compression.go
@@ -1,0 +1,274 @@
+package store
+
+import (
+	"io"
+	"strings"
+
+	"compress/gzip"
+	"github.com/valyala/gozstd"
+)
+
+const (
+	compressionNone = ""
+	compressionGzip = "gzip"
+	compressionZstd = "zstd"
+
+	extCompressionNone = ""
+	extCompressionGzip = ".gz"
+	extCompressionZstd = ".zst"
+)
+
+var compressionToExt map[string]string = map[string]string{
+	compressionNone: extCompressionNone,
+	compressionGzip: extCompressionGzip,
+	compressionZstd: extCompressionZstd,
+}
+
+var extToCompression map[string]string = map[string]string{
+	extCompressionNone: compressionNone,
+	extCompressionGzip: compressionGzip,
+	extCompressionZstd: compressionZstd,
+}
+
+var compressionExtensionsList []string = []string{
+	extCompressionGzip,
+	extCompressionZstd,
+}
+
+func IsCompressionValid(compression string) bool {
+	for k, _ := range compressionToExt {
+		if k == compression {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isCompressionExt(ext string) bool {
+	for _, e := range compressionExtensionsList {
+		if e == ext {
+			return true
+		}
+	}
+
+	return false
+}
+
+// filepath.Ext adopted for filenames with one or two extensions
+func exts(path string) (string, string) {
+	items := strings.Split(path, ".")
+	if len(items) > 2 {
+		return "." + items[len(items)-2], "." + items[len(items)-1]
+	} else if len(items) == 2 {
+		return "." + items[len(items)-1], ""
+	} else {
+		return "", ""
+	}
+}
+
+func firstExt(path string) string {
+	e, _ := exts(path)
+	return e
+}
+
+func secondExt(path string) string {
+	_, e := exts(path)
+	return e
+}
+
+type newCompressedReaderFunc func(io.ReadCloser) (compressedReader, error)
+type newCompressedWriterFunc func(io.WriteCloser) (compressedWriter, error)
+
+type compressedReader interface {
+	io.ReadCloser
+}
+
+type compressedWriter interface {
+	io.WriteCloser
+
+	/* total number of bytes written */
+	size() int64
+}
+
+type compressor struct {
+	newReader newCompressedReaderFunc
+	newWriter newCompressedWriterFunc
+}
+
+var compressors map[string]*compressor = map[string]*compressor{
+	compressionNone: &compressor{newCopyReader, newCopyWriter},
+	compressionGzip: &compressor{newGzipReader, newGzipWriter},
+	compressionZstd: &compressor{newZstdReader, newZstdWriter},
+}
+
+func getCompressor(compression string) *compressor {
+	c, ok := compressors[compression]
+	if !ok {
+		return &compressor{newCopyReader, newCopyWriter}
+	}
+
+	return c
+}
+
+func newCompressedReader(compression string, src io.ReadCloser) (compressedReader, error) {
+	return getCompressor(compression).newReader(src)
+}
+
+func newCompressedWriter(compression string, dst io.WriteCloser) (compressedWriter, error) {
+	return getCompressor(compression).newWriter(dst)
+}
+
+type copyReader struct {
+	src io.ReadCloser
+}
+
+func newCopyReader(src io.ReadCloser) (compressedReader, error) {
+	return &copyReader{
+		src: src,
+	}, nil
+}
+
+func (r *copyReader) Read(p []byte) (int, error) {
+	return r.src.Read(p)
+}
+
+func (r *copyReader) Close() error {
+	return r.src.Close()
+}
+
+type copyWriter struct {
+	dst io.WriteCloser
+	sz  int64
+}
+
+func newCopyWriter(dst io.WriteCloser) (compressedWriter, error) {
+	return &copyWriter{
+		dst: dst,
+	}, nil
+}
+
+func (w *copyWriter) Write(p []byte) (int, error) {
+	n, err := w.dst.Write(p)
+	w.sz += int64(n)
+	return n, err
+}
+
+func (w *copyWriter) size() int64 {
+	return w.sz
+}
+
+func (w *copyWriter) Close() error {
+	return w.dst.Close()
+}
+
+type gzipReader struct {
+	src  io.ReadCloser
+	csrc *gzip.Reader
+}
+
+func newGzipReader(src io.ReadCloser) (compressedReader, error) {
+	r, err := gzip.NewReader(src)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gzipReader{
+		src:  src,
+		csrc: r,
+	}, nil
+}
+
+func (r *gzipReader) Read(p []byte) (int, error) {
+	return r.csrc.Read(p)
+}
+
+func (r *gzipReader) Close() error {
+	return r.src.Close()
+}
+
+type gzipWriter struct {
+	dst  io.WriteCloser
+	cw   *countingWriter
+	cdst *gzip.Writer
+}
+
+func newGzipWriter(dst io.WriteCloser) (compressedWriter, error) {
+	cw := &countingWriter{}
+
+	return &gzipWriter{
+		dst:  dst,
+		cw:   cw,
+		cdst: gzip.NewWriter(io.MultiWriter(dst, cw)),
+	}, nil
+}
+
+func (w *gzipWriter) Write(p []byte) (int, error) {
+	return w.cdst.Write(p)
+}
+
+func (w *gzipWriter) size() int64 {
+	return w.cw.n
+}
+
+func (w *gzipWriter) Close() error {
+	if err := w.cdst.Close(); err != nil {
+		return err
+	}
+
+	return w.dst.Close()
+}
+
+type zstdReader struct {
+	src  io.ReadCloser
+	csrc *gozstd.Reader
+}
+
+func newZstdReader(src io.ReadCloser) (compressedReader, error) {
+	return &zstdReader{
+		src:  src,
+		csrc: gozstd.NewReader(src),
+	}, nil
+}
+
+func (r *zstdReader) Read(p []byte) (int, error) {
+	return r.csrc.Read(p)
+}
+
+func (r *zstdReader) Close() error {
+	return r.src.Close()
+}
+
+type zstdWriter struct {
+	dst  io.WriteCloser
+	cw   *countingWriter
+	cdst *gozstd.Writer
+}
+
+func newZstdWriter(dst io.WriteCloser) (compressedWriter, error) {
+	cw := &countingWriter{}
+
+	return &zstdWriter{
+		dst:  dst,
+		cw:   cw,
+		cdst: gozstd.NewWriter(io.MultiWriter(dst, cw)),
+	}, nil
+}
+
+func (w *zstdWriter) Write(p []byte) (int, error) {
+	return w.cdst.Write(p)
+}
+
+func (w *zstdWriter) size() int64 {
+	return w.cw.n
+}
+
+func (w *zstdWriter) Close() error {
+	if err := w.cdst.Close(); err != nil {
+		return err
+	}
+
+	w.cdst.Release()
+
+	return w.dst.Close()
+}

--- a/pkg/store/compression_test.go
+++ b/pkg/store/compression_test.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"compress/gzip"
+	"github.com/oklog/ulid"
+	"github.com/valyala/gozstd"
+
+	"github.com/oklog/oklog/pkg/fs"
+)
+
+type byteReader struct {
+	b byte
+}
+
+func (r byteReader) Read(p []byte) (int, error) {
+	for i := 0; i < len(p); i++ {
+		p[i] = r.b
+	}
+
+	return len(p), nil
+}
+
+// Check, that file log writes compressed records to proper file
+// and compresses data correctly
+func checkCompressionWrite(t *testing.T, compression, ext string) {
+	t.Parallel()
+
+	const (
+		segmentTargetSize = 10 * 1024
+		segmentBufferSize = 1024
+	)
+
+	filesys := fs.NewVirtualFilesystem()
+
+	filelog, err := NewFileLog(filesys, "", segmentTargetSize, segmentBufferSize, compression, nil)
+	if err != nil {
+		t.Fatalf("NewFileLog: %v", err)
+	}
+	defer filelog.Close()
+
+	ws, err := filelog.Create()
+
+	var lo, hi *ulid.ULID
+	r := byteReader{'x'}
+	var data bytes.Buffer
+	w := io.MultiWriter(ws, &data)
+	for i := 0; i < 100; i++ {
+		ul := ulid.MustNew(uint64(i), r)
+		if lo == nil {
+			lo = &ul
+		}
+		hi = &ul
+
+		s := fmt.Sprintf("%s %s\n", ul, strings.Repeat("test ", 50))
+		w.Write([]byte(s))
+	}
+
+	ws.Close(*lo, *hi)
+
+	segmentName := fmt.Sprintf("%s-%s%s%s", lo, hi, extFlushed, ext)
+	/* there should 2 2 files: LOCK and our segment */
+	files := []string{}
+	filesys.Walk("", func(path string, info os.FileInfo, err error) error {
+		switch path {
+		case "LOCK":
+		case segmentName:
+			if info.Size() > int64(data.Len()/2) {
+				t.Errorf("File seems to be not compressed, uncompressed size=%d, compressed=%d", data.Len(), info.Size())
+			}
+		default:
+			t.Errorf("Unknown file in dir: %s", path)
+		}
+		files = append(files, path)
+		return nil
+	})
+
+	if len(files) != 2 {
+		t.Errorf("Some files are missing, want 'LOCK' and segment, have: %v", files)
+	}
+
+	// Check file content
+	cf, err := filesys.Open(segmentName)
+	if err != nil {
+		t.Fatalf("Error opening %s: %v", segmentName, err)
+	}
+
+	var f io.Reader
+
+	switch compression {
+	case "zstd":
+		f = gozstd.NewReader(cf)
+	case "gzip":
+		f, err = gzip.NewReader(cf)
+		if err != nil {
+			t.Fatalf("Error creating gzip input stream: %v", err)
+		}
+	}
+
+	data2, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Error reading from %s: %v", segmentName, err)
+	}
+
+	if !bytes.Equal(data.Bytes(), data2) {
+		t.Errorf("Data in segment file is wrong")
+	}
+}
+
+func TestCompressionWrite(t *testing.T) {
+	t.Run("zstd", func(t *testing.T) {
+		checkCompressionWrite(t, "zstd", ".zst")
+	})
+
+	t.Run("gzip", func(t *testing.T) {
+		checkCompressionWrite(t, "gzip", ".gz")
+	})
+}
+
+// Check that fileReadSegment correctly decompresses log files
+// Create compressed file without help of tested functions then
+// open and read it with fileReadSegment and compare data
+func checkCompressionRead(t *testing.T, compression, ext string) {
+	t.Parallel()
+
+	const (
+		segmentTargetSize = 10 * 1024
+		segmentBufferSize = 1024
+	)
+
+	filesys := fs.NewVirtualFilesystem()
+
+	path := fmt.Sprintf("test-file%s%s", extFlushed, ext)
+	cf, err := filesys.Create(path)
+	if err != nil {
+		t.Fatalf("Error creating file %s: %v", cf, err)
+	}
+
+	var f io.WriteCloser
+
+	switch compression {
+	case "zstd":
+		tmp := gozstd.NewWriter(cf)
+		defer tmp.Release()
+		f = tmp
+	case "gzip":
+		f = gzip.NewWriter(cf)
+	}
+
+	data := []byte(strings.Repeat("some text ", 30) + strings.Repeat("some other text ", 50))
+
+	_, err = f.Write(data)
+	f.Close()
+	cf.Close()
+
+	r, err := newFileReadSegment(filesys, path)
+	if err != nil {
+		t.Fatalf("Error opening file %s: %v", path, err)
+	}
+
+	data2, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatalf("Error reading: %v", err)
+	}
+
+	if !bytes.Equal(data, data2) {
+		t.Errorf("Invalid data was produced by fileReadSegment")
+	}
+}
+
+func TestCompressionRead(t *testing.T) {
+	t.Run("zstd", func(t *testing.T) {
+		checkCompressionRead(t, "zstd", ".zst")
+	})
+
+	t.Run("gzip", func(t *testing.T) {
+		checkCompressionRead(t, "gzip", ".gz")
+	})
+}

--- a/pkg/store/file_log_test.go
+++ b/pkg/store/file_log_test.go
@@ -94,7 +94,7 @@ func TestRecoverSegments(t *testing.T) {
 		segmentTargetSize = 10 * 1024
 		segmentBufferSize = 1024
 	)
-	filelog, err := NewFileLog(filesys, "", segmentTargetSize, segmentBufferSize, nil)
+	filelog, err := NewFileLog(filesys, "", segmentTargetSize, segmentBufferSize, "", nil)
 	if err != nil {
 		t.Fatalf("NewFileLog: %v", err)
 	}
@@ -150,13 +150,13 @@ func TestLockBehavior(t *testing.T) {
 			f.Close()
 
 			// NewFileLog should manage this fine.
-			filelog, err := NewFileLog(filesys, root, 1024, 1024, nil)
+			filelog, err := NewFileLog(filesys, root, 1024, 1024, "", nil)
 			if err != nil {
 				t.Fatalf("initial NewFileLog: %v", err)
 			}
 
 			// But a second FileLog should fail.
-			if _, err := NewFileLog(filesys, root, 1024, 1024, nil); err == nil {
+			if _, err := NewFileLog(filesys, root, 1024, 1024, "", nil); err == nil {
 				t.Fatalf("second NewFileLog: want error, have none")
 			} else {
 				t.Logf("second NewFileLog: got expected error: %v", err)
@@ -189,7 +189,7 @@ func TestBadSegment(t *testing.T) {
 	}
 
 	// Create a filelog around that filesys.
-	filelog, _ := NewFileLog(filesys, "/", 1024, 1024, nil)
+	filelog, _ := NewFileLog(filesys, "/", 1024, 1024, "", nil)
 
 	// Perform some read op on the filelog, to trigger rm.
 	// Main thing here is just that it doesn't panic.

--- a/pkg/store/log.go
+++ b/pkg/store/log.go
@@ -49,6 +49,7 @@ type WriteSegment interface {
 	io.Writer
 	Close(low, high ulid.ULID) error
 	Delete() error
+	Size() int64
 }
 
 // ReadSegment can be read from, reset (back to flushed state), trashed (made


### PR DESCRIPTION
Implement compression on store side. If compression is enabled data is compressed before being written to segment files on disk and decompressed on read. The code which deals with records remains the same, it doesn't affected by this patch.

Now `gzip` and `zstandard` are implemented, but other implementations can also be easily added.

To enable compression `-compression` flag for `oklog store` or `oklog ingeststore` should be provided.

oklog/oklog#134